### PR TITLE
feat: enhance show pages with comprehensive metadata display and mana…

### DIFF
--- a/src/app/[series]/components/SeriesPageClient.tsx
+++ b/src/app/[series]/components/SeriesPageClient.tsx
@@ -6,6 +6,7 @@ import {
   Calendar,
   Play,
   Edit3,
+  ExternalLink,
 } from "lucide-react";
 import Link from "next/link";
 
@@ -29,33 +30,96 @@ export default function SeriesPageClient({ show, episodes }: SeriesPageClientPro
     <div className="min-h-screen bg-gradient-to-tr from-red-200 to-green-500">
       <div className="container mx-auto px-4 py-8">
         {/* Header */}
-        <div className="flex flex-col justify-between mb-8">
-          <div className="flex flex-col gap-2 space-x-3">
-            <Link
-              href="/"
-              className="flex items-center space-x-1 text-gray-600 hover:text-gray-800 transition-colors"
-            >
-              <ArrowLeft className="w-4 h-4" />
-              <span>Back to Shows</span>
-            </Link>
-            <div className="flex items-center justify-between">
-              <div>
-                <h1 className="text-3xl font-bold text-gray-900">
-                  {show.name}
-                </h1>
-                <p className="text-gray-600">
-                  {episodes.length} episode{episodes.length !== 1 ? 's' : ''} with subtitles
-                </p>
-              </div>
-              {isAdmin && (
-                <Link
-                  href={`/${generateShowSlug(show.name)}/edit`}
-                  className="inline-flex items-center space-x-2 bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition-colors"
-                >
-                  <Edit3 className="w-4 h-4" />
-                  <span>Edit Show</span>
-                </Link>
+        <div className="mb-8">
+          <Link
+            href="/"
+            className="flex items-center space-x-1 text-gray-600 hover:text-gray-800 transition-colors mb-6"
+          >
+            <ArrowLeft className="w-4 h-4" />
+            <span>Back to Shows</span>
+          </Link>
+          
+          {/* Show info section */}
+          <div className="bg-white rounded-xl shadow-lg p-6 mb-8">
+            <div className="flex flex-col md:flex-row gap-6">
+              {/* Thumbnail */}
+              {show.poster_url && (
+                <div className="flex-shrink-0">
+                  <img
+                    src={show.poster_url}
+                    alt={`${show.name} poster`}
+                    className="w-32 h-48 md:w-40 md:h-60 object-cover rounded-lg shadow-md"
+                  />
+                </div>
               )}
+              
+              {/* Show details */}
+              <div className="flex-1">
+                <div className="flex items-start justify-between mb-4">
+                  <div>
+                    <h1 className="text-3xl font-bold text-gray-900 mb-2">
+                      {show.name}
+                    </h1>
+                    <p className="text-gray-600 mb-2">
+                      {episodes.length} episode{episodes.length !== 1 ? 's' : ''} with subtitles
+                    </p>
+                    {show.first_aired && (
+                      <p className="text-sm text-gray-500">
+                        First aired: {new Date(show.first_aired).getFullYear()}
+                      </p>
+                    )}
+                  </div>
+                  {isAdmin && (
+                    <Link
+                      href={`/${generateShowSlug(show.name)}/edit`}
+                      className="inline-flex items-center space-x-2 bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition-colors"
+                    >
+                      <Edit3 className="w-4 h-4" />
+                      <span>Edit Show</span>
+                    </Link>
+                  )}
+                </div>
+                
+                {/* Description */}
+                {show.overview && (
+                  <div className="mb-4">
+                    <h3 className="text-lg font-semibold text-gray-800 mb-2">Description</h3>
+                    <p className="text-gray-700 leading-relaxed">{show.overview}</p>
+                  </div>
+                )}
+                
+                {/* Additional info */}
+                <div className="flex flex-wrap gap-4 text-sm text-gray-600 mb-4">
+                  {show.network && (
+                    <span className="bg-gray-100 px-2 py-1 rounded">
+                      {show.network}
+                    </span>
+                  )}
+                  {show.status && (
+                    <span className="bg-gray-100 px-2 py-1 rounded">
+                      {show.status}
+                    </span>
+                  )}
+                  {show.genres && show.genres.length > 0 && (
+                    <span className="bg-gray-100 px-2 py-1 rounded">
+                      {show.genres.join(', ')}
+                    </span>
+                  )}
+                </div>
+                
+                {/* Watch link */}
+                {show.watch_url && (
+                  <a
+                    href={show.watch_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center space-x-1 text-blue-600 hover:text-blue-800 transition-colors"
+                  >
+                    <span>Watch Show</span>
+                    <ExternalLink className="w-4 h-4" />
+                  </a>
+                )}
+              </div>
             </div>
           </div>
         </div>

--- a/src/app/components/ShowCard.tsx
+++ b/src/app/components/ShowCard.tsx
@@ -35,7 +35,7 @@ export const ShowCard = ({ show }: ShowCardProps) => {
               </h3>
               <div className="flex items-center space-x-4 text-sm text-gray-500">
                 <span className="bg-gray-200 px-2 py-1 rounded text-xs">
-                  {show.source}
+                  {show.network || show.source}
                 </span>
                 <span className="flex items-center space-x-1">
                   <Calendar className="w-3 h-3" />

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -14,6 +14,7 @@ export interface Show {
   description?: string;
   genre?: string;
   language?: string;
+  watch_url?: string;
   // TVDB fields
   tvdb_id?: number;
   tvdb_slug?: string;


### PR DESCRIPTION
- Add show description, thumbnail, and watch URL to series pages
- Add manual watch link field to show metadata editor
- Display poster images, overview, network, status, genres, and first aired year
- Replace show source with network name on show cards for better UX
- Fix UUID error in metadata saving by handling empty extraction IDs
- Auto-populate poster URLs when selecting shows from TVDB search
- Add proper null handling for optional metadata fields

🤖 Generated with [Claude Code](https://claude.ai/code)