### PR TITLE
fix(worker): Docker base image to Node 22 (Realtime needs native WebSocket)

### DIFF
--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,6 +1,8 @@
 # Legendas-PT worker (data plane). Outbound-only, no exposed ports.
 # Build context is the repo root: `docker build -f worker/Dockerfile .`
-FROM node:20-slim
+# Node 22+ is required: @supabase/supabase-js builds a Realtime client on init,
+# which needs native global WebSocket (only present in Node >= 22).
+FROM node:22-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
The worker container crash-loops on `node:20-slim` with:

```
Error: Node.js 20 detected without native WebSocket support.
```

`@supabase/supabase-js` builds a Realtime client on init, which needs a native global `WebSocket` — only present in Node 22+. Bumps the base image to `node:22-slim`.

Not caught earlier because local `npm run worker` runs on Node 24; only a real `docker compose up` on the Node 20 image surfaced it. Verified: rebuilt container starts, registers in worker_status, and is processing a real import.